### PR TITLE
improve display of studioes & members on Game detail page - #140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - add gems ed25519 bcrypt_pbkdf
 
+### Changed
+- improve display of studioes & members on Game detail page - #140
+
 ## [1.0.0] - 2024-02-23
 ### Changed
 - fix usage of hits.total on Elasticsearch with ES8 upgrade

--- a/src/components/Game/Detail/Info/GameInfos.jsx
+++ b/src/components/Game/Detail/Info/GameInfos.jsx
@@ -25,6 +25,24 @@ const StandardLinksList = ({links}) =>
     </ul>
   );
 
+const EntityLinksList = ({items}) =>
+  items && items.length >= 0 && (
+    <ul>
+      {items.map(({title, field_path, id}, i) => {
+        return (
+          <li key={i}>
+            <Link href={field_path} key={id}>
+              <a
+                className='text-white hover:text-opacity-75 transition transition:opacity duration-200'>
+                {title}
+              </a>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+
 const GameInfos = ({game}) => {
   const {t} = useTranslation();
 
@@ -75,12 +93,12 @@ const GameInfos = ({game}) => {
     },
     {
       title: 'game.studios',
-      content: studios?.data.map(renderStudioPeople),
+      content: <EntityLinksList items={studios?.data} />,
       count: studios?.data.length,
     },
     {
       title: 'game.members',
-      content: members?.data.map(renderStudioPeople),
+      content: <EntityLinksList items={members?.data} />,
       count: members?.data.length,
       childrenClass: 'flex flex-col',
     },


### PR DESCRIPTION
### 💬 Description

Fix the listing of Members / Studios on detail page

### 🎟️ Issue(s)
- #140 

### 📸  Screenshot

<img width="715" alt="Screenshot 2024-02-23 at 14 30 50" src="https://github.com/Games-of-Switzerland/swissgamesgarden/assets/1841592/247f0edc-0cb9-46f9-842c-e97aa4f50ab8">

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
