### PR TITLE
fix placeholder image still visible when images are loaded from Browser cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - add gems ed25519 bcrypt_pbkdf
 
+### Fixed
+- fix placeholder image still visible when images are loaded from Browser cache
+
 ## [1.0.0] - 2024-02-23
 ### Changed
 - fix usage of hits.total on Elasticsearch with ES8 upgrade

--- a/src/components/Image.jsx
+++ b/src/components/Image.jsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import Placeholder from './Placeholder';
 
 const skipFormats = ['gif'];
@@ -52,6 +52,15 @@ const Image = ({
 }) => {
   const [loaded, setLoaded] = useState(false);
   const imageType = getImageType(image);
+  const imageRef = useRef();
+
+  useEffect(()=>{
+    if (!imageRef.current) return
+
+    if (imageRef.current.complete === true) {
+      setLoaded(true)
+    }
+  },[imageRef])
 
   return (
     <div className={className}>
@@ -75,10 +84,11 @@ const Image = ({
               />
             ))}
             <img
+              ref={imageRef}
+              onLoad={() => setLoaded(true)}
               src={image.links[defaultSize].href || image.href}
               alt={alt}
               loading="lazy"
-              onLoad={() => setLoaded(true)}
               className="w-full"
             />
           </picture>


### PR DESCRIPTION
fix placeholder image still visible when images are loaded from Browser cache

<img width="1840" alt="Screenshot 2024-02-23 at 16 14 44" src="https://github.com/Games-of-Switzerland/swissgamesgarden/assets/1841592/7d8e780b-949b-4076-8068-cd383d420644">

This is a known problem. Here the code use `onLoad`to trigger removal of the placeholder low-res image.
Still, `onLoad` in never trigger by a Browser when the image is loaded from Cache.

The solution is to use .complete and a useEffect

@see https://ahndongjin.medium.com/if-image-onload-is-not-called-fe3eae74ec7f and https://stackoverflow.com/questions/59787642/nextjs-images-loaded-from-cache-dont-trigger-the-onload-event