### PR TITLE
add missing cantons (zug, jura, uri, schwyz, obwald, nidwald & glarus) translations - #149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - add gems ed25519 bcrypt_pbkdf
+- add missing cantons (zug, jura, uri, schwyz, obwald, nidwald & glarus) - #149
 
 ### Changed
 - improve display of studioes & members on Game detail page - #140

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -347,7 +347,14 @@
     "thurgau": "Thurgau",
     "biel": "Biel",
     "bulle": "Bulle",
-    "solothurn": "Solothurn"
+    "solothurn": "Solothurn",
+    "zug": "Zug",
+    "jura": "Jura",
+    "uri": "Uri",
+    "schwyz": "Schwyz",
+    "obwald": "Obwald",
+    "nidwald": "Nidwald",
+    "glarus": "Glarus"
   },
   "locations": {
     "title": "Location",


### PR DESCRIPTION
### 💬 Description
add missing cantons (zug, jura, uri, schwyz, obwald, nidwald & glarus) translations

### 🎟️ Issue(s)
progress on #149
