### PR TITLE
fix visual glitch of games genres not wrapping - #150

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - fix placeholder image still visible when images are loaded from Browser cache
+- fix visual glitch of games genres not wrapping - #150
 
 ## [1.0.0] - 2024-02-23
 ### Changed

--- a/src/components/Game/Teaser/GameTeaser.jsx
+++ b/src/components/Game/Teaser/GameTeaser.jsx
@@ -57,7 +57,7 @@ const GameTeaser = ({game}) => {
         )}
 
         {genres.length > 0 && (
-          <div className="flex gap-1 mt-1">
+          <div className="flex flex-wrap gap-1 mt-1">
             {genres.map(({slug}) => (
               <Link href={`/?genres[]=${slug}`} key={slug}>
                 <a className="font-light border-b border-dotted border-gray-700 text-gray-500 hover:text-white hover:border-gray-450 relative z-10 mb-1">


### PR DESCRIPTION
### 💬 Description
fix visual glitch of games genres not wrapping

<img width="1840" alt="Screenshot 2024-02-26 at 09 26 20" src="https://github.com/Games-of-Switzerland/swissgamesgarden/assets/1841592/010bde40-f7b9-42f2-a012-1788cc3912ed">

### 🎟️ Issue(s)
close #150
